### PR TITLE
fix config name typo

### DIFF
--- a/lib/logstash/logAnalyticsClient/logStashAutoResizeBuffer.rb
+++ b/lib/logstash/logAnalyticsClient/logStashAutoResizeBuffer.rb
@@ -72,19 +72,19 @@ class LogStashAutoResizeBuffer
     # We would like to do it until we reached to the duration 
     def resend_message(documents_json, amount_of_documents, remaining_duration)
         if remaining_duration > 0
-            @logger.info("Resending #{amount_of_documents} documents as log type #{@logstashLoganalyticsConfiguration.custom_log_table_name} to DataCollector API in #{@logstashLoganalyticsConfiguration.RETRANSMITION_DELAY} seconds.")
+            @logger.info("Resending #{amount_of_documents} documents as log type #{@logstashLoganalyticsConfiguration.custom_log_table_name} to DataCollector API in #{@logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY} seconds.")
             sleep @logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY
             begin
                 response = @client.post_data(documents_json)
                 if is_successfully_posted(response)
                     @logger.info("Successfully sent #{amount_of_documents} logs into custom log analytics table[#{@logstashLoganalyticsConfiguration.custom_log_table_name}] after resending.")
                 else
-                    @logger.debug("Resending #{amount_of_documents} documents failed, will try to resend for #{(remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMITION_DELAY)}")
-                    resend_message(documents_json, amount_of_documents, (remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMITION_DELAY))
+                    @logger.debug("Resending #{amount_of_documents} documents failed, will try to resend for #{(remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY)}")
+                    resend_message(documents_json, amount_of_documents, (remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY))
                 end
             rescue Exception => ex
-                @logger.debug("Resending #{amount_of_documents} documents failed, will try to resend for #{(remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMITION_DELAY)}")
-                resend_message(documents_json, amount_of_documents, (remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMITION_DELAY))
+                @logger.debug("Resending #{amount_of_documents} documents failed, will try to resend for #{(remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY)}")
+                resend_message(documents_json, amount_of_documents, (remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY))
             end
         else 
             @logger.error("Could not resend #{amount_of_documents} documents, message is dropped.")


### PR DESCRIPTION
Hi, Thank you for maintaining useful plugin!

We found some typo and let me send this PR. 
"RETRANS**MITION**_DELAY" should be "RETRANS**MISSION**_DELAY".

https://github.com/Ronmarsiano/logstashALAOutputPlugin/blob/master/lib/logstash/logAnalyticsClient/logstashLoganalyticsConfiguration.rb#L10

Due to this, we are facing NoMethod error when resend occurs. like below.
```
> [2020-06-11T00:36:18,563][WARN ][logstash.outputs.azureloganalytics][main] Failed to flush outgoing items {:outgoing_count=>516, :exception=>"NoMethodError", :backtrace=>[
"/usr/share/logstash/vendor/local_gems/2698bf9b/microsoft-logstash-output-azure-loganalytics-0.1.0/lib/logstash/logAnalyticsClient/logStashAutoResizeBuffer.rb:75:in `resend_message'", 
"/usr/share/logstash/vendor/local_gems/2698bf9b/microsoft-logstash-output-azure-loganalytics-0.1.0/lib/logstash/logAnalyticsClient/logStashAutoResizeBuffer.rb:67:in `send_message_to_loganalytics'", "/usr/share/logstash/vendor/local_gems/2698bf9b/microsoft-logstash-output-azure-loganalytics-0.1.0/lib/logstash/logAnalyticsClient/logStashAutoResizeBuffer.rb:47:in `flush'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/stud-0.0.23/lib/stud/buffer.rb:219:in `block in buffer_flush'", "org/jruby/RubyHash.java:1428:in `each'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/stud-0.0.23/lib/stud/buffer.rb:216:in `buffer_flush'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/stud-0.0.23/lib/stud/buffer.rb:112:in `block in buffer_initialize'", "org/jruby/RubyKernel.java:1446:in `loop'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/stud-0.0.23/lib/stud/buffer.rb:110:in `block in buffer_initialize'"]}
```


