### PR TITLE
follow Log-Type naming rule.

### DIFF
--- a/lib/logstash/logAnalyticsClient/logstashLoganalyticsConfiguration.rb
+++ b/lib/logstash/logAnalyticsClient/logstashLoganalyticsConfiguration.rb
@@ -28,8 +28,11 @@ class LogstashLoganalyticsOutputConfiguration
         elsif @workspace_id.empty? or @workspace_key.empty? or @custom_log_table_name.empty? 
             raise ArgumentError, "Malformed configuration , the following arguments can not be null or empty.[workspace_id=#{@workspace_id} , workspace_key=#{@workspace_key} , custom_log_table_name=#{@custom_log_table_name}]"
 
-        elsif not @custom_log_table_name.match(/^[[:alpha:]]+$/)
-            raise ArgumentError, 'custom_log_table_name must be only alpha characters.' 
+        elsif not @custom_log_table_name.match(/^[[:alpha:][:digit:]_]+$/)
+            raise ArgumentError, 'custom_log_table_name must be only alpha characters, numbers and underscore.'
+
+        elsif @custom_log_table_name.length > 100
+            raise ArgumentError, 'custom_log_table_name must not exceed 100 characters.'
 
         elsif custom_log_table_name.empty?
             raise ArgumentError, 'custom_log_table_name should not be empty.' 

--- a/lib/logstash/outputs/microsoft-logstash-output-azure-loganalytics.rb
+++ b/lib/logstash/outputs/microsoft-logstash-output-azure-loganalytics.rb
@@ -19,7 +19,8 @@ class LogStash::Outputs::AzureLogAnalytics < LogStash::Outputs::Base
   config :workspace_key, :validate => :string, :required => true
 
   # The name of the event type that is being submitted to Log Analytics. 
-  # This must be only alpha characters.
+  # This must be only alpha characters, numbers and underscore.
+  # This must not exceed 100 characters.'
   # Table name under custom logs in which the data will be inserted
   config :custom_log_table_name, :validate => :string, :required => true
 


### PR DESCRIPTION
Hi, let me make another PR to follow Log-Type naming rule.

https://docs.microsoft.com/en-us/azure/azure-monitor/platform/data-collector-api

Log-Type | Specify the record type of the data that is being submitted. Can only contain letters, numbers, and underscore (_), and may not exceed 100 characters.
-- | --

According to document, numbers and underscore are also acceptable in tablename.
and should not exceed 100 characters.

so let me suggest you to add and follow this rule.
